### PR TITLE
fix: html-validate as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "fancy-log": "^1.3.3",
+    "html-validate": ">=4.0.0",
     "plugin-error": "^1.0.1",
     "through2": "^4.0.2"
   },
@@ -29,9 +30,7 @@
     "prettier": "2.0.5",
     "prettier-config-web-scrobbler": "0.1.0"
   },
-  "peerDependencies": {
-    "html-validate": ">=4.0.0"
-  },
+  
   "scripts": {
     "lint": "eslint ."
   },


### PR DESCRIPTION
#### Description of what you did:

I've moved 'html-validate' from 'peerDependencies' to 'dependencies'. 'html-validate' is required for the run and must be installed.

#### My PR is a:

-   [ ] 💥 Breaking change
-   [x] 🐛 Bug fix
-   [ ] 💅 Enhancement
-   [ ] 🚀 New feature

#### Main update on the:

-   [ ] Templates and Code
-   [x] Framework
-   [ ] Documentation
